### PR TITLE
fix: add searchParams for TailwindCSS V3 doc

### DIFF
--- a/src/algolia/apiData.ts
+++ b/src/algolia/apiData.ts
@@ -242,6 +242,9 @@ export default <IAPIData[]>[
     appId: "KNPXZI5B0M",
     indexName: "tailwindcss",
     homepage: "https://tailwindcss.com/",
+    searchParameters: {
+      facetFilters: ["version:v3"],
+    },
   },
   {
     name: "Unidata",


### PR DESCRIPTION
Only search for V3 docs rather than those of older versions